### PR TITLE
a bug related to the computation of loglikelihood

### DIFF
--- a/ASTactic/models/tactic_decoder.py
+++ b/ASTactic/models/tactic_decoder.py
@@ -428,7 +428,7 @@ class TacticDecoder(nn.Module):
                     node.expand(action)
                 new_beam.append(ast)
                 new_frontiers.append(stack)
-                new_log_likelihood.append(log_likelihood[idx] + log_cond_prob)
+                new_log_likelihood.append(log_cond_prob)
             beam = new_beam
             frontiers = new_frontiers
             log_likelihood = new_log_likelihood


### PR DESCRIPTION
  In the computation of beam_candidates, the previous loglikelihood has already been added into log_cond_prob, however in line 431, the previous loglikelihood is added once again, which makes longer command's loglikelihood's order of magnitude bigger than shorter's. 